### PR TITLE
docs: replace temporary Discord invite URL with permanent URL

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -2,7 +2,7 @@
 
 ---
 [![Go Report Card](https://goreportcard.com/badge/github.com/livepeer/go-livepeer)](https://goreportcard.com/report/github.com/livepeer/go-livepeer)
-[![Discord](https://img.shields.io/discord/423160867534929930.svg?style=flat-square)](https://discord.gg/7wRSUGX)
+[![Discord](https://img.shields.io/discord/423160867534929930.svg?style=flat-square)](https://discord.gg/livepeer)
 
 The Livepeer project aims to deliver a live video-streaming network
 protocol that is fully decentralized, highly scalable and crypto-token
@@ -20,5 +20,5 @@ at these other resources:
 - 📖 [The Livepeer Docs](https://livepeer.org/docs)
 - 🔭 [The 10-Minute Primer](https://livepeer.org/primer/)
 - ✍ [The Livepeer Blog](https://medium.com/livepeer-blog)
-- 💬 [The Livepeer Chat](https://discord.gg/uaPhtyrWsF)
+- 💬 [The Livepeer Chat](https://discord.gg/livepeer)
 - ❓ [The Livepeer Forum](https://forum.livepeer.org/)


### PR DESCRIPTION
This pull request updates the Discord invite URL from a temporary (expiring) link to a fixed (permanent) one to ensure long-term accessibility.
